### PR TITLE
AWS Aurora 用 JDBC プラグインの追加

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ lazy val `lib-infrastructure-mysql` = (project in file("./lib-infrastructure-mys
       "org.tpolecat" %% "doobie-core"     % DoobieVersion,
       "org.tpolecat" %% "doobie-specs2"   % DoobieVersion % Test,
       "org.tpolecat" %% "doobie-hikari"   % DoobieVersion,
-      "com.zaxxer" % "HikariCP" % "7.0.0"
+      "com.zaxxer" % "HikariCP" % "7.0.0",
+      "software.amazon.jdbc" % "aws-advanced-jdbc-wrapper" % "2.6.1"
     )
   )
 

--- a/lib-infrastructure-mysql/src/main/scala/com/example/infra/DatabaseConnectionPool.scala
+++ b/lib-infrastructure-mysql/src/main/scala/com/example/infra/DatabaseConnectionPool.scala
@@ -8,11 +8,11 @@ import cats.effect.kernel.Async
 
 case class DatabaseConnectionPool(
   host:     String,
-  port:     Short,
+  port:     Int,
   user:     String,
   password: String
 ) {
-  require(port >= 0)
+  require(port >= 0 && port <= 65535)
 
   def transactor[F[_]: Async]: Resource[F, HikariTransactor[F]] = for {
     hikariConfig <- Resource.pure {
@@ -36,7 +36,7 @@ object DatabaseConnectionPool {
 
     DatabaseConnectionPool(
       config.getString("db.host"),
-      config.getInt("db.port").toShort,
+      config.getInt("db.port"),
       config.getString("db.user"),
       config.getString("db.password")
     )

--- a/lib-infrastructure-mysql/src/main/scala/com/example/infra/DatabaseConnectionPool.scala
+++ b/lib-infrastructure-mysql/src/main/scala/com/example/infra/DatabaseConnectionPool.scala
@@ -18,8 +18,15 @@ case class DatabaseConnectionPool(
     hikariConfig <- Resource.pure {
       val config = new HikariConfig();
 
-      config.setDriverClassName("com.mysql.cj.jdbc.Driver")
-      config.setJdbcUrl(s"jdbc:mysql://$host:$port/to_do")
+      val jdbcUrl =
+        if (host == "localhost") {
+          s"jdbc:aws-wrapper:mysql://$host:$port/to_do?allowPublicKeyRetrieval=true&useSSL=false&wrapperPlugins="
+        } else {
+          s"jdbc:aws-wrapper:mysql://$host:$port/to_do"
+        }
+
+      config.setDriverClassName("software.amazon.jdbc.Driver")
+      config.setJdbcUrl(jdbcUrl)
       config.setUsername(user)
       config.setPassword(password)
 


### PR DESCRIPTION
- 「4.7 データベースからのデータ取得」で示されている AWS Aurora 用の JDBC プラグインを追加しました。
- main ブランチに取り込まれていた変更で port 番号の型が `Short` になっていましたが、誤りだったので修正しました。