### PR TITLE
fix: カテゴリが指定されていない場合にフォームの入力結果が正しく認識されないのを修正

### DIFF
--- a/todo-ngx/src/app/components/todo-table/todo-table.ts
+++ b/todo-ngx/src/app/components/todo-table/todo-table.ts
@@ -39,7 +39,7 @@ export class TodoTable {
           title: currentTodo.title,
           body: currentTodo.body,
           state: currentTodo.state,
-          categoryId: currentTodo.category?.id
+          categoryId: currentTodo.category?.id ?? null
         },
         categories: this.categories
       }


### PR DESCRIPTION
`category` が `null` の時に `category?.id` が `undefined` になり、`todoUpdateFormSchema` の `categoryId: z.uint32().nullable()` という制約を満たさないことによりパースに失敗し、Todo が更新されないのを修正しました。